### PR TITLE
Update theme with company colors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -45,73 +45,73 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.129 0.042 264.695);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.129 0.042 264.695);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.129 0.042 264.695);
-  --primary: oklch(0.208 0.042 265.755);
-  --primary-foreground: oklch(0.984 0.003 247.858);
-  --secondary: oklch(0.968 0.007 247.896);
-  --secondary-foreground: oklch(0.208 0.042 265.755);
-  --muted: oklch(0.968 0.007 247.896);
-  --muted-strong: oklch(0.845 0.007 247.896);
-  --muted-foreground: oklch(0.554 0.046 257.417);
-  --accent: oklch(0.968 0.007 247.896);
-  --accent-foreground: oklch(0.208 0.042 265.755);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.929 0.013 255.508);
-  --input: oklch(0.929 0.013 255.508);
-  --ring: oklch(0.704 0.04 256.788);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.984 0.003 247.858);
-  --sidebar-foreground: oklch(0.3903 0.0631 176.41);
-  --sidebar-primary: oklch(0.5221 0.090867 187.7997);
-  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.968 0.007 247.896);
-  --sidebar-accent-foreground: oklch(0.208 0.042 265.755);
-  --sidebar-border: oklch(0.929 0.013 255.508);
-  --sidebar-ring: oklch(0.704 0.04 256.788);
+  --background: #ffffff;
+  --foreground: #155044;
+  --card: #ffffff;
+  --card-foreground: #155044;
+  --popover: #ffffff;
+  --popover-foreground: #155044;
+  --primary: #007a73;
+  --primary-foreground: #ffffff;
+  --secondary: #8bbeb2;
+  --secondary-foreground: #155044;
+  --muted: #f2ebbf;
+  --muted-strong: #bcbec1;
+  --muted-foreground: #4f5255;
+  --accent: #f3b661;
+  --accent-foreground: #155044;
+  --destructive: #f06060;
+  --border: #bcbec1;
+  --input: #bcbec1;
+  --ring: #007a73;
+  --chart-1: #155044;
+  --chart-2: #007a73;
+  --chart-3: #8bbeb2;
+  --chart-4: #f3b661;
+  --chart-5: #f06060;
+  --sidebar: #007a73;
+  --sidebar-foreground: #ffffff;
+  --sidebar-primary: #155044;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f3b661;
+  --sidebar-accent-foreground: #155044;
+  --sidebar-border: #bcbec1;
+  --sidebar-ring: #007a73;
 }
 
 .dark {
-  --background: oklch(0.129 0.042 264.695);
-  --foreground: oklch(0.984 0.003 247.858);
-  --card: oklch(0.208 0.042 265.755);
-  --card-foreground: oklch(0.984 0.003 247.858);
-  --popover: oklch(0.208 0.042 265.755);
-  --popover-foreground: oklch(0.984 0.003 247.858);
-  --primary: oklch(0.929 0.013 255.508);
-  --primary-foreground: oklch(0.208 0.042 265.755);
-  --secondary: oklch(0.279 0.041 260.031);
-  --secondary-foreground: oklch(0.984 0.003 247.858);
-  --muted: oklch(0.279 0.041 260.031);
-  --muted-strong: oklch(0.3903 0.0631 176.41);
-  --muted-foreground: oklch(0.704 0.04 256.788);
-  --accent: oklch(0.279 0.041 260.031);
-  --accent-foreground: oklch(0.984 0.003 247.858);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.551 0.027 264.364);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.208 0.042 265.755);
-  --sidebar-foreground: oklch(0.4369 0.0063 247.97);
-  --sidebar-primary: oklch(0.8008 0.0048 258.33);
-  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.279 0.041 260.031);
-  --sidebar-accent-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.551 0.027 264.364);
+  --background: #000000;
+  --foreground: #ffffff;
+  --card: #155044;
+  --card-foreground: #ffffff;
+  --popover: #155044;
+  --popover-foreground: #ffffff;
+  --primary: #007a73;
+  --primary-foreground: #ffffff;
+  --secondary: #4f5255;
+  --secondary-foreground: #ffffff;
+  --muted: #4f5255;
+  --muted-strong: #bcbec1;
+  --muted-foreground: #bcbec1;
+  --accent: #f3b661;
+  --accent-foreground: #155044;
+  --destructive: #f06060;
+  --border: #4f5255;
+  --input: #4f5255;
+  --ring: #8bbeb2;
+  --chart-1: #bcbec1;
+  --chart-2: #8bbeb2;
+  --chart-3: #f3b661;
+  --chart-4: #007a73;
+  --chart-5: #f06060;
+  --sidebar: #155044;
+  --sidebar-foreground: #ffffff;
+  --sidebar-primary: #007a73;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f3b661;
+  --sidebar-accent-foreground: #155044;
+  --sidebar-border: #4f5255;
+  --sidebar-ring: #8bbeb2;
 }
 
 @layer base {
@@ -161,9 +161,11 @@
 /* Stile personalizzato per l'header */
 @layer components {
   header {
-    background-color: #ffffff; /* Colore per la modalità chiara */
+    background-color: #007a73;
+    color: #ffffff;
   }
   .dark header {
-    background-color: #000000; /* Colore per la modalità scura */
+    background-color: #155044;
+    color: #ffffff;
   }
 }

--- a/components/InsuranceComparisonClient.tsx
+++ b/components/InsuranceComparisonClient.tsx
@@ -103,7 +103,7 @@ export default function InsuranceComparisonClient() {
 
     return (
         <div className="font-sans bg-background text-foreground min-h-screen flex flex-col">
-            <header ref={headerRef} className={`p-2 md:p-2 border-b border-b-black/20 sticky top-0 z-40 no-print transition-transform duration-300 ${isHeaderVisible ? 'translate-y-0' : '-translate-y-full'} flex items-center justify-between`}>
+            <header ref={headerRef} className={`p-2 md:p-2 border-b border-border bg-primary text-primary-foreground sticky top-0 z-40 no-print transition-transform duration-300 ${isHeaderVisible ? 'translate-y-0' : '-translate-y-full'} flex items-center justify-between`}>
                 <div>
                     <Image src="/LG_original.svg" alt="L+G SA Logo" width={120} height={35} className="h-7 w-auto dark:hidden" />
                     <Image src="/LG_white.svg" alt="L+G SA Logo" width={120} height={35} className="h-7 w-auto hidden dark:block" />

--- a/components/MobileView.tsx
+++ b/components/MobileView.tsx
@@ -361,7 +361,7 @@ export default function MobileView({
         className="md:hidden flex flex-col bg-muted/30"
         style={{ height: `calc(100vh - ${MAIN_HEADER_HEIGHT}px)` }}
       >
-        <header className="sticky top-0 z-10">
+        <header className="sticky top-0 z-10 bg-primary text-primary-foreground">
           <OfferNavigator
             offers={offers}
             visibleOfferId={visibleOfferId}


### PR DESCRIPTION
## Summary
- update global color variables with company palette
- refine header styles for light/dark mode
- adjust header markup in desktop and mobile views

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688412222d748330837f0c5eab424f6d